### PR TITLE
TR-115-b 지출 내역 CRUD

### DIFF
--- a/src/main/java/com/triplus/schedule/controller/ExpenseController.java
+++ b/src/main/java/com/triplus/schedule/controller/ExpenseController.java
@@ -1,0 +1,40 @@
+package com.triplus.schedule.controller;
+
+import com.triplus.schedule.dto.ExpenseDto;
+import com.triplus.schedule.service.ExpenseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+
+@CrossOrigin("*")
+@RestController
+public class ExpenseController {
+
+    @Autowired
+    private ExpenseService expenseService;
+
+    @GetMapping(value = "/api/member/plan/expense/{skdNum}", produces = {MediaType.APPLICATION_JSON_VALUE})
+    public ExpenseDto getExpense(@PathVariable int skdNum)
+    {
+        return expenseService.select(skdNum);
+    }
+
+    @PutMapping(value = "/api/service/plan/expense/{skdNum}", produces = {MediaType.APPLICATION_JSON_VALUE})
+    public HashMap<String, Object> postUpdate(
+            @PathVariable int skdNum,
+            @RequestBody ExpenseDto dto) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("result", false);
+        map.put("reason", "unknown");
+        try {
+            int result = expenseService.update(dto);
+            map.put("result", result > 0);
+        } catch (Exception e) {
+            e.printStackTrace();
+            map.put("reason", "DB 오류");
+        }
+        return map;
+    }
+}

--- a/src/main/java/com/triplus/schedule/dto/ExpenseDto.java
+++ b/src/main/java/com/triplus/schedule/dto/ExpenseDto.java
@@ -1,0 +1,16 @@
+package com.triplus.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ExpenseDto
+{
+    private int skdNum;
+    private String jsonData;
+}

--- a/src/main/java/com/triplus/schedule/mapper/ExpenseMapper.java
+++ b/src/main/java/com/triplus/schedule/mapper/ExpenseMapper.java
@@ -1,0 +1,15 @@
+package com.triplus.schedule.mapper;
+
+import com.triplus.board.dto.QnaDto;
+import com.triplus.schedule.dto.ExpenseDto;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.ArrayList;
+
+@Mapper
+public interface ExpenseMapper
+{
+    public ExpenseDto select(int brdNum);
+    public int insert(ExpenseDto boardDto);
+    public int update(ExpenseDto boardDto);
+}

--- a/src/main/java/com/triplus/schedule/service/ExpenseService.java
+++ b/src/main/java/com/triplus/schedule/service/ExpenseService.java
@@ -1,0 +1,24 @@
+package com.triplus.schedule.service;
+
+import com.triplus.board.dto.QnaDto;
+import com.triplus.board.mapper.QnaMapper;
+import com.triplus.schedule.dto.ExpenseDto;
+import com.triplus.schedule.mapper.ExpenseMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+public class ExpenseService {
+    @Autowired private ExpenseMapper expenseMapper;
+
+    public ExpenseDto select(int skdNum)
+    { return expenseMapper.select(skdNum); }
+
+    public int insert(ExpenseDto qnaDto)
+    { return expenseMapper.insert(qnaDto); }
+
+    public int update(ExpenseDto qnaDto)
+    { return expenseMapper.update(qnaDto); }
+}

--- a/src/main/resources/com/triplus/schedule/mapper/ExpenseMapper.xml
+++ b/src/main/resources/com/triplus/schedule/mapper/ExpenseMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE mapper
+		PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+		"http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.triplus.board.mapper.QnaMapper">
+	<select id="select" parameterType="int" resultType="com.triplus.schedule.dto.ExpenseDto">
+		select * from EXPENSES
+			where skdnum = #{skdNum}
+	</select>
+
+	<insert id="insert" parameterType="com.triplus.schedule.dto.ExpenseDto">
+		insert into EXPENSES values(#{skdNum}, #{jsonData})
+	</insert>
+
+	<update id="update" parameterType="com.triplus.schedule.dto.ExpenseDto">
+		update EXPENSES
+		set jsonData = #{jsonData}
+		where skdNum = #{skdNum}
+	</update>
+</mapper>


### PR DESCRIPTION
지출 내역 DB 간소화
  데이터마다 컬럼을 할당 -> jsonData 컬럼 하나로만 존재
  지출 내역에 상세한 DB작업을 사용할 일(검색, 삭제 등)이 없기 때문에 간소화함
기본적으로 생성, 수정만 가능한 컨트롤러&매퍼 클래스